### PR TITLE
リファクタリング 処理ロジックなど

### DIFF
--- a/app/controllers/v1/friends_controller.rb
+++ b/app/controllers/v1/friends_controller.rb
@@ -8,7 +8,7 @@ class V1::FriendsController < ApplicationController
   end
 
   def destroy
-    current_user.del_friend(current_user.id, params[:friend_id])
+    current_user.del_friend(current_user.id, params[:id])
     render json: { status: 'SUCCESS', data: 'フレンド解除に成功しました', color: 'green' }
   end
 

--- a/app/controllers/v1/rooms_controller.rb
+++ b/app/controllers/v1/rooms_controller.rb
@@ -15,7 +15,9 @@ class V1::RoomsController < ApplicationController
   def show
     @users = @room.users
     @friends = current_user.applicants.joins(:friends).select('users.*, friends.accept')
-    @messages = @room.messages.includes(:user).joins("LEFT OUTER JOIN users ON users.id = messages.user_id").select("messages.*, users.nickname")
+    @messages = @room.messages.includes(:user)
+                     .joins('LEFT OUTER JOIN users ON users.id = messages.user_id')
+                     .select('messages.*, users.nickname')
     render json: { status: 'Success', data: [@room, @users, @messages, @friends] }
   end
 

--- a/app/controllers/v1/rooms_controller.rb
+++ b/app/controllers/v1/rooms_controller.rb
@@ -15,8 +15,9 @@ class V1::RoomsController < ApplicationController
 
   def show
     @users = @room.users
+    @friends = current_user.applicants.joins(:friends).select('users.*, friends.accept')
     @messages = @room.messages.includes(:user).joins("LEFT OUTER JOIN users ON users.id = messages.user_id").select("messages.*, users.nickname")
-    render json: { status: 'Success', data: [@room, @users, @messages] }
+    render json: { status: 'Success', data: [@room, @users, @messages, @friends] }
   end
 
   def create

--- a/app/controllers/v1/rooms_controller.rb
+++ b/app/controllers/v1/rooms_controller.rb
@@ -3,9 +3,8 @@ class V1::RoomsController < ApplicationController
   before_action :find_room, except: [:index, :new, :create, :search]
 
   def index
-    @rooms = Room.all
-    @favorite_rooms = Room.joins(:room_users).group(:room_id).order('count(user_id) desc')
-    render json: { status: 'Success', data: [@rooms, @favorite_rooms] }
+    @rooms = current_user.rooms
+    render json: { status: 'Success', data: [@rooms] }
   end
 
   def new

--- a/app/controllers/v1/rooms_controller.rb
+++ b/app/controllers/v1/rooms_controller.rb
@@ -15,7 +15,7 @@ class V1::RoomsController < ApplicationController
 
   def show
     @users = @room.users
-    @messages = @room.messages
+    @messages = @room.messages.includes(:user).joins("LEFT OUTER JOIN users ON users.id = messages.user_id").select("messages.*, users.nickname")
     render json: { status: 'Success', data: [@room, @users, @messages] }
   end
 

--- a/app/controllers/v1/rooms_controller.rb
+++ b/app/controllers/v1/rooms_controller.rb
@@ -64,10 +64,11 @@ class V1::RoomsController < ApplicationController
   end
 
   def search
-    if params[:data].empty?
+    serach_params = params[:data]
+    if serach_params.empty?
       @rooms = Room.where(private: 0)
     else
-      search_value = params[:data].split(/[[:blank:]]+/)
+      search_value = serach_params.split(/[[:blank:]]+/)
       @rooms = []
       search_value.each do |src|
         rooms_data = Room.where(private: 0).where('name LIKE ? OR description LIKE ? OR genre LIKE ?', "%#{src}%", "%#{src}%",

--- a/app/controllers/v1/tags_controller.rb
+++ b/app/controllers/v1/tags_controller.rb
@@ -2,6 +2,8 @@ class V1::TagsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    render json: { status: 'SUCCESS', data: current_user.tags }
+    user = User.find(params[:id])
+    @tags = user.tags
+    render json: { status: 'SUCCESS', data: @tags }
   end
 end

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { 'testルーム' }
     description { 'テストの説明' }
     private { false }
-    leader { 'testユーザー' }
+    leader { '1' }
     genre { 'ゲーム' }
   end
 end

--- a/spec/requests/v1/friends_spec.rb
+++ b/spec/requests/v1/friends_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'V1::Friends', type: :request do
   end
   describe 'DELETE /destroy' do
     it 'フレンドを削除することができる' do
-      expect { delete v1_friend_path(user.id, friend_id: apply_user.id), headers: auth_headers }.to change(Friend, :count).by(-2)
+      expect { delete v1_friend_path(apply_user.id), headers: auth_headers }.to change(Friend, :count).by(-2)
       json = JSON.parse(response.body)
       expect(json['status']).to eq('SUCCESS')
       expect(json['data']).to eq('フレンド解除に成功しました')

--- a/spec/requests/v1/rooms_spec.rb
+++ b/spec/requests/v1/rooms_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'V1::Rooms', type: :request do
   let(:user) { FactoryBot.create(:user) }
   let!(:auth_headers) { login(user) }
   describe 'GET /index' do
+    before do
+      user.rooms << room
+    end
     it 'Roomの一覧データを返す' do
       get v1_rooms_path, headers: auth_headers
       json = JSON.parse(response.body)
       expect(response.status).to eq(200)
-      expect(json['data'].length).to eq(2)
       expect(json['data'][0].length).to eq(5)
     end
   end


### PR DESCRIPTION
# What
- Roomのleaderをnickenameからidに変更
- messageにユーザー名を表示させるため、userと結合させて返す
- その他アクセス改善

# Why
- nicknameだと値がかぶる可能性があるため
- 同時に返さないとそれぞれのmessageがどのuserかわからないため
- n+1問題が配慮されていなかったため